### PR TITLE
Use upstream version of sdl2 from GitHub incorporating fix for building on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Ubuntu Linux instructions:
     $ stack install --install-ghc gtk2hs-buildtools
     $ stack install
 
+Windows instructions
+
+    $ stack exec -- pacman -Sy mingw-w64-x86_64-cairo mingw-w64-x86_64-pkg-config mingw-w64-x86_64-SDL2
+    $ stack install --install-ghc gtk2hs-buildtools
+    $ stack install
+
 ## Running
 
 It accepts an initial home page URL:

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,10 @@ resolver: lts-9.0
 packages:
 - .
 - location:
+    git: https://github.com/haskell-game/sdl2.git
+    commit: a43c202511b5654680c45098e2c32c45c3655bc4
+  extra-dep: true
+- location:
     git: https://github.com/chrisdone/sdl2-cairo.git
     commit: fab0d5128feefe0941336af79d8b3ad63c5db00c
   extra-dep: true


### PR DESCRIPTION
Hey Chris,

Thanks for reaching out. This is a squashed version of the commits to support building on Windows.

It does now build without errors on Windows which is great. There are still some runtime issues related to missing symbols from libpng.dll which I'll continue to investigate (when I get time). It's probably still worth taking this pull request anyway since it should help Windows folks make some progress.

Thanks, Richard.
