### PR TITLE
Basic support for images: XKCD-enabled!

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ projects.
 
 OS X instructions:
 
-    $ brew install sdl2 cairo
+    $ brew install pkg-config libffi cairo sdl2 sdl2_image
+    $ export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
     $ stack install --install-ghc gtk2hs-buildtools
     $ stack install
 
 Ubuntu Linux instructions:
 
-    $ sudo apt-get install libsdl2-dev libcairo2-dev
+    $ sudo apt-get install libcairo2-dev libsdl2-dev libsdl2-image-dev
     $ stack install --install-ghc gtk2hs-buildtools
     $ stack install
 
@@ -68,7 +69,7 @@ FreeBSD instructions:
 
 Windows instructions
 
-    $ stack exec -- pacman -Sy mingw-w64-x86_64-cairo mingw-w64-x86_64-pkg-config mingw-w64-x86_64-SDL2
+    $ stack exec -- pacman -Sy mingw-w64-x86_64-cairo mingw-w64-x86_64-pkg-config mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image
     $ stack install --install-ghc gtk2hs-buildtools
     $ stack install
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,11 @@ packages:
 - .
 - location:
     git: https://github.com/haskell-game/sdl2.git
-    commit: a43c202511b5654680c45098e2c32c45c3655bc4
+    commit: bc30282eca6c04d1f910f2f3c96b0a64cf84f158
+  extra-dep: true
+- location:
+    git: https://github.com/haskell-game/sdl2-image.git
+    commit: ab036e1c91e3cf5fcc89d3d61bd6c2e975c2f38d
   extra-dep: true
 - location:
     git: https://github.com/chrisdone/sdl2-cairo.git

--- a/vado.cabal
+++ b/vado.cabal
@@ -21,6 +21,7 @@ executable vado
                      , linear
                      , sdl2
                      , sdl2-cairo
+                     , sdl2-image
                      , http-client
                      , http-types
                      , html-conduit


### PR DESCRIPTION
This commit adds support for images, in formats supported by `sdl2-image`. Failures to retrieve an image are gracefully handled. 

Images are laid out as inline blocks. `width` and `height` attributes of an `<img>` are respected.  

It loads images sequentially (this can be annoying on pages with many images): all images must be fetched before the page is rendered. 

`sdl2-image` is added as a new dependency.