### PR TITLE
Fix build on Windows10

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ projects.
 
 OS X instructions:
 
-    $ brew install sdl2 cairo
+    $ brew install pkg-config sdl2 cairo
     $ stack install --install-ghc gtk2hs-buildtools
     $ stack install
 
@@ -61,6 +61,7 @@ Ubuntu Linux instructions:
 
 FreeBSD instructions:
 
+    $ pkg install pkgconf
     $ pkg install cairo
     $ pkg install sdl2
     $ stack install --install-ghc gtk2hs-buildtools

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
 - .
 - location:
     git: https://github.com/haskell-game/sdl2.git
-    commit: a43c202511b5654680c45098e2c32c45c3655bc4
+    commit: bc30282eca6c04d1f910f2f3c96b0a64cf84f158
   extra-dep: true
 - location:
     git: https://github.com/chrisdone/sdl2-cairo.git


### PR DESCRIPTION
I have managed to produce a Windows executable, which still fails with the same error mentioned in #1 

Also: installation paths of Git and Stack must not contain spaces!